### PR TITLE
3rd condition, none isSection and none isNote

### DIFF
--- a/addons/account/static/src/js/section_and_note_fields_backend.js
+++ b/addons/account/static/src/js/section_and_note_fields_backend.js
@@ -41,8 +41,15 @@ var SectionAndNoteListRenderer = ListRenderer.extend({
                 $cell.removeClass('o_invisible_modifier');
                 return $cell.addClass('o_hidden');
             }
+        } else if (isNote === false && isSection === false) { // 3rd condition, none isSection and none isNote
+            if (node.attrs.name === "name" &&
+                node.attrs.widget === 'section_and_note_text') {
+                $cell.attr('title', record.data.name); // set title
+                $cell.children().addClass('text-nowrap'); // set text-nowrap
+            }
+            return $cell;
         }
-
+        
         return $cell;
     },
     /**


### PR DESCRIPTION
set title, set text-nowrap on widget section_and_note_one2many and section_and_note_text,
none section and none note doesn't look like other tree fields, with no title attribute and no text ellipsis

**Description of the issue/feature this PR addresses:**
1. sets widget section_and_note_one2many on a tree in a form view, 
2. sets widget section_and_note_text to it's child field "name", 
3. then the normal field displays a thin width and long height of text

**Current behavior before PR:**
field name is none section and none note, displays diffrent with other tree fields, without html title and still be set white-space pre-wrap style

**Desired behavior after PR is merged:**
Expected behavior: with title, and style ellipsis



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
